### PR TITLE
Agregar comando !unirme y !{rol}

### DIFF
--- a/Commands/notificarRol.js
+++ b/Commands/notificarRol.js
@@ -1,0 +1,23 @@
+const roles = require('../Services/roles.js');
+
+async function handleNotificarRol(rol, msg) {
+    const chat = await msg.getChat();
+    
+    if (chat.isGroup) {
+        const userIds = await roles.obtenerUserIdsDeRol(rol);
+
+        let text = '';
+        let mentions = [];
+
+        for (let id of userIds) {
+            mentions.push(`${id}@c.us`);
+            text += `@${id} `;
+        }
+
+        await chat.sendMessage(text, { mentions });
+    } else {
+        await msg.reply('Este comando solo funciona en grupos');
+    }
+}
+
+module.exports = handleNotificarRol;

--- a/Commands/unirme.js
+++ b/Commands/unirme.js
@@ -1,0 +1,22 @@
+const roles = require('../Services/roles.js')
+
+async function handleUnirme(msg, client) {
+    const [_, rol] = msg.body.match(/!unirme +([a-zA-Z]+)/);
+
+    if (rol) {
+        const authorContact = await msg.getContact();
+        const authorUserId = authorContact.id.user;
+
+        const agregado = await roles.agregar(rol, authorUserId);
+
+        if (agregado) {
+            await msg.reply(`Listo, te agregué al '${rol}'`);
+        } else {
+            await msg.reply(`Ya estas en el rol '${rol}'`);
+        }
+    } else {
+        await msg.reply('No entendí a que rol agregarte. Tenes que escribir !unirme <nombre del rol>, sin <> y sin espacios en el nombre.');
+    }
+}
+
+module.exports = handleUnirme;

--- a/Services/roles.js
+++ b/Services/roles.js
@@ -1,0 +1,73 @@
+const low = require('lowdb');
+const FileSync = require('lowdb/adapters/FileSync');
+const path = require('path');
+
+const adapter = new FileSync(path.join(__dirname, 'db.json'));
+const db = low(adapter);
+
+db.defaults({
+    'roles': {}
+}).write();
+
+async function agregar(rol, userId) {
+    await db.read();
+    const roles = db.data['roles'];
+
+    if (!(rol in roles)) {
+        roles[rol] = [];
+    }
+
+    if (noContiene(roles[rol], userId)) {
+        roles[rol].push(userId);
+        await db.write();
+        return true;
+    }
+
+    return false;
+}
+
+async function quitar(rol, userId) {
+    await db.read();
+    const roles = db.data['roles'];
+
+    if (rol in roles && contiene(roles[rol], userId)) {
+        roles[rol] = roles[rol].filter(item => item !== userId);
+        await db.write();
+        return true;
+    }
+
+    return false;
+}
+
+async function obtenerUserIdsDeRol(rol) {
+    await db.read();
+    const roles = db.data['roles'];
+    if (rol in roles) return roles[rol];
+    return [];
+}
+
+async function obtenerRoles() {
+    await db.read();
+    return Object.keys(db.data['roles']);
+}
+
+async function quiereNotificarRol(msg) {
+    const roles = await obtenerRoles();
+    return roles.some(rol => msg === `!${rol}`);
+}
+
+function noContiene(array, valor) {
+    return array.indexOf(valor) === -1;
+}
+
+function contiene(array, valor) {
+    return array.indexOf(valor) !== -1;
+}
+
+module.exports = {
+    agregar,
+    quitar,
+    obtenerUserIdsDeRol,
+    quiereNotificarRol,
+    obtenerRoles,
+};

--- a/main.js
+++ b/main.js
@@ -5,6 +5,9 @@ const handleDolarCommand = require('./Commands/dolar.js');
 const handleHelpCommand = require('./Commands/help.js');
 const handleJuntadaCommand = require('./Commands/juntada.js');
 const handlePutoCommand = require('./Commands/puto.js');
+const handleUnirmeCommand = require('./Commands/unirme.js');
+const handleNotificarRolCommand = require('./Commands/notificarRol.js');
+const { quiereNotificarRol } = require('./Services/roles.js');
 
 const client = new Client({
     authStrategy: new LocalAuth()
@@ -38,6 +41,12 @@ client.on('message', async (msg) => {
             case '!puto':
                 handlePutoCommand(msg, client);
                 break;
+        }
+
+        if (msg.body.startsWith('!unirme')) {
+            await handleUnirmeCommand(msg, client);
+        } else if (await quiereNotificarRol(msg.body)) {
+            await handleNotificarRolCommand(rol, msg);
         }
     } catch (error) {
         console.error(`Error al procesar el comando "${msg.body}":`, error);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "dotenv": "^16.4.7",
+        "lowdb": "^7.0.1",
         "node-fetch": "^3.3.2",
         "qrcode-terminal": "^0.12.0",
         "whatsapp-bot": "file:",
@@ -806,6 +807,20 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/lowdb": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/lowdb/-/lowdb-7.0.1.tgz",
+      "integrity": "sha512-neJAj8GwF0e8EpycYIDFqEPcx9Qz4GUho20jWFR7YiFeXzF1YMLdxB36PypcTSPMA+4+LvgyMacYhlr18Zlymw==",
+      "dependencies": {
+        "steno": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
     "node_modules/mime": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
@@ -1132,6 +1147,17 @@
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/steno": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/steno/-/steno-4.0.2.tgz",
+      "integrity": "sha512-yhPIQXjrlt1xv7dyPQg2P17URmXbuM5pdGkpiMB3RenprfiBlvK415Lctfe0eshk90oA7/tNq7WEiMK8RSP39A==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "description": "",
   "dependencies": {
     "dotenv": "^16.4.7",
+    "lowdb": "^7.0.1",
     "node-fetch": "^3.3.2",
     "qrcode-terminal": "^0.12.0",
     "whatsapp-bot": "file:",


### PR DESCRIPTION
El primero sirve para unir al que invoca el comando a un rol. El segundo sirve para notificar a todos los miembros de un rol. Si existe el rol 'onepiece' entonces invocar '!onepiece' notifica a todos sus miembros.

Los roles y miembros quedan guardados en un archivo en Services/db.json